### PR TITLE
fixed issue #10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "lib/Socket.IO"]
 	path = lib/Socket.IO
-	url = http://github.com/LearnBoost/Socket.IO.git
+	url = http://github.com/LearnBoost/socket.io.git
 [submodule "lib/Socket.IO-node"]
 	path = lib/Socket.IO-node
-	url = http://github.com/LearnBoost/Socket.IO-node.git
+	url = http://github.com/LearnBoost/socket.io-node.git
 [submodule "lib/express"]
 	path = lib/express
 	url = http://github.com/visionmedia/express.git


### PR DESCRIPTION
The socket.io guys seemed to have renamed their repository.

That results in a strange error for the bashscript (all submodule folders are empty, after a fatal error trying to get the git-repositories for socket IO)
