### PR TITLE
Broken `make test` -- Incorrect/changed paths

### DIFF
--- a/templates/app/Makefile
+++ b/templates/app/Makefile
@@ -1,7 +1,7 @@
 TESTS = test/*.js
 
 test:
-	@NODE_ENV=test ./node_modules/.bin/mocha \
+	@NODE_ENV=test ./node_modules/mocha/bin/mocha \
 			--require should \
 			--reporter list \
 			--slow 20 \


### PR DESCRIPTION
``` bash
/bin/sh: 1: ./node_modules/.bin/mocha: not found
make: *** [test] Error 127
```

I don't know if the path is different between architectures, or has changed between versions, however the path to the mocha binary installed locally is `./node_modules/mocha/bin/mocha`, so the default "test suite" needs some work to do anything

(node v0.11.3-pre, npm 1.2.21)
